### PR TITLE
docs(spec): how a client can know whether the WHPP endpoint supports trickle-ICE

### DIFF
--- a/webrtc-http-playback-protocol.md
+++ b/webrtc-http-playback-protocol.md
@@ -112,6 +112,8 @@ Response
 Status: 204
 ~~~
 
+For a WHPP client to determine whether the endpoint supports trickle-ice it can issue an HTTP OPTIONS request on the viewer resource and be able to determine from the HTTP header `Allow` whether the HTTP method `PATCH` is allowed and supported. A response without the `PATCH` method in this header included means that the server does not support trickle-ice.
+
 # Security Considerations
 
 # IANA Considerations


### PR DESCRIPTION
This PR addresses #6 and instructions on how a client can obtain information on whether the endpoint supports trickle-ICE.